### PR TITLE
docs: improve contributing guide with clear setup and PR steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,26 @@
 # Contributing to FountainCMS
 
-Thank you for your interest in contributing to FountainCMS! We welcome all kinds of contributions, including bug reports, feature requests, documentation improvements, and code.
+Thank you for your interest in contributing to FountainCMS 🎉  
+We welcome all kinds of contributions including bug reports, feature requests, documentation improvements, and code contributions.
 
-## How to Contribute
+---
 
-- **Bug Reports & Feature Requests:**
-  - Please use [GitHub Issues](https://github.com/building-for-fun/fountainCms/issues) to report bugs or suggest features.
-  - Provide as much detail as possible, including steps to reproduce bugs or a clear description of the feature.
+## 📌 How to Contribute
 
-- **Pull Requests:**
-  - Fork the repository and create your branch from `main`.
-  - Follow the [Conventional Commits](https://www.conventionalcommits.org/) standard for commit messages.
-  - Ensure your code passes all linting, formatting, and tests before submitting a PR.
-  - Reference related issues in your PR description (e.g., "Closes #123").
-  - Keep PRs focused and small; large or unrelated changes may be rejected.
-  - Add or update documentation as needed.
+### 🐞 Bug Reports & Feature Requests
+- Please use [GitHub Issues](https://github.com/building-for-fun/fountainCms/issues).
+- Clearly describe the problem or feature.
+- For bug reports, please include:
+  - Steps to reproduce
+  - Expected behavior
+  - Screenshots or logs (if available)
 
-- **Code Style:**
-  - Use the provided linting and formatting tools (`npm run lint` and `npm run format`) for both frontend and backend.
-  - Write clear, maintainable, and well-documented code.
+---
 
-- **Security:**
-  - If you discover a security vulnerability, please follow our [Security Policy](./SECURITY.md) and do not open a public issue.
+### 🔀 Pull Requests
 
-## Community Standards
-
-- Be respectful and inclusive in all interactions.
-- Follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
-- Help us keep the project welcoming for everyone.
-
-## Getting Help
-
-If you have questions, open an issue or start a discussion in the repository.
-
-Thank you for helping make FountainCMS better!
+1. Fork the repository
+2. Clone your fork locally:
+   ```bash
+   git clone https://github.com/<your-username>/fountainCms.git
+   cd fountainCms


### PR DESCRIPTION
Fixes #48

### ✨ What’s improved
- Updated `CONTRIBUTING.md` to make it more beginner-friendly
- Added clear step-by-step contribution flow (fork, clone, branch, PR)
- Clarified usage of `dev` branch instead of `main`
- Added local development setup instructions for backend and frontend
- Improved overall documentation structure and readability

### 🎯 Why this change
The previous contributing guide lacked clear setup instructions and could be confusing for new contributors.  
This update makes it easier for first-time contributors to get started and contribute effectively.

Please review and let me know if any changes are needed.  
Thank you! 🙌
