### PR TITLE
fix(docker): add missing backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:22
+FROM node:24.0.0-alpine
 
 WORKDIR /usr/src/app
 
 COPY package*.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 
@@ -14,4 +14,4 @@ RUN npm run build
 
 EXPOSE 3000
 
-CMD [ "npm", "run", "start:prod" ]
+CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
## Description

This PR fixes an issue where running `docker compose up` from the project root
fails due to a missing backend Dockerfile.

A backend Dockerfile has been added/updated so Docker Compose can correctly build
and start both required services:
- PostgreSQL
- Backend API

Fixes #50

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

---

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

## Screenshots (if applicable)

N/A

---

## Additional Context

This fix ensures that the infrastructure setup works as expected and prevents
`docker compose up` from failing during local development.
